### PR TITLE
Added public aid getter

### DIFF
--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -323,6 +323,9 @@ class SpanAccessory{
 
   public:
   
+
+  uint32_t getAccessoryId(){return aid;}                  // retrieves Accessory Instance ID (HAP Table 6-1)
+
   SpanAccessory(uint32_t aid=0);                          // constructor
 };
 


### PR DESCRIPTION
I'd like to be able to retrieve the `aid` of an accessory in order to be able to remove it from the database later. There is though a possibility to set it on the first place, but I don't want to be forced to manage those IDs internally if there is already a system for this in the library itself.