### PR TITLE
Fix docu for missing TemperaturSensor

### DIFF
--- a/docs/ServiceList.md
+++ b/docs/ServiceList.md
@@ -56,7 +56,8 @@ Additionally, when first starting up, HomeSpan begins by validating the device's
 |StatelessProgrammableSwitch|ProgrammableSwitchEvent|Name<br>ServiceLabelIndex|
 |Switch|On|Name|
 |Television|Active|ConfiguredName<br>ActiveIdentifier<br>RemoteKey<br>PowerModeSelection|
-|TelevisionSpeaker|VolumeControlType<br>VolumeSelector||TemperatureSensor|CurrentTemperature|Name<br>StatusActive<br>StatusFault<br>StatusTampered<br>StatusLowBattery|
+|TelevisionSpeaker|VolumeControlType<br>VolumeSelector|
+|TemperatureSensor|CurrentTemperature|Name<br>StatusActive<br>StatusFault<br>StatusTampered<br>StatusLowBattery|
 |Thermostat|CurrentHeatingCoolingState<br>TargetHeatingCoolingState<br>CurrentTemperature<br>TargetTemperature<br>TemperatureDisplayUnits|CoolingThresholdTemperature<br>CurrentRelativeHumidity<br>HeatingThresholdTemperature<br>Name<br>TargetRelativeHumidity|
 |Valve|Active<br>InUse<br>ValveType|SetDuration<br>RemainingDuration<br>IsConfigured<br>ServiceLabelIndex<br>StatusFault<br>Name|
 |Window|CurrentPosition<br>TargetPosition<br>PositionState|Name<br>HoldPosition<br>ObstructionDetected|


### PR DESCRIPTION
There was a line break missing which causes that the TemperaturSensor are not shown on the docu page.