### PR TITLE
Support the Non-English WiFi name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ HomeSpan requires version 2.0.0 or later of the [Arduino-ESP32 Board Manager](ht
 * Integrated access to the ESP32's on-chip Remote Control peripheral for easy generation of IR and RF signals
 * Dedicated classes to control one- and two-wire addressable RGB and RGBW LEDs and LED strips
 * Dedicated classes to control stepper motors that can run smoothly in the background without interfering with HomeSpan
-* Dedicated class that faciliates seemless point-to-point communication between ESP32 devices using ESP-NOW
+* Dedicated class that faciliates seamless point-to-point communication between ESP32 devices using ESP-NOW
 * Integrated Web Log for user-defined log messages
 * Extensively-commented Tutorial Sketches taking you from the very basics of HomeSpan through advanced HomeKit topics
 * Additional examples and projects showcasing real-world implementations of HomeSpan

--- a/docs/ServiceList.md
+++ b/docs/ServiceList.md
@@ -56,7 +56,8 @@ Additionally, when first starting up, HomeSpan begins by validating the device's
 |StatelessProgrammableSwitch|ProgrammableSwitchEvent|Name<br>ServiceLabelIndex|
 |Switch|On|Name|
 |Television|Active|ConfiguredName<br>ActiveIdentifier<br>RemoteKey<br>PowerModeSelection|
-|TelevisionSpeaker|VolumeControlType<br>VolumeSelector||TemperatureSensor|CurrentTemperature|Name<br>StatusActive<br>StatusFault<br>StatusTampered<br>StatusLowBattery|
+|TelevisionSpeaker|VolumeControlType<br>VolumeSelector|
+|TemperatureSensor|CurrentTemperature|Name<br>StatusActive<br>StatusFault<br>StatusTampered<br>StatusLowBattery|
 |Thermostat|CurrentHeatingCoolingState<br>TargetHeatingCoolingState<br>CurrentTemperature<br>TargetTemperature<br>TemperatureDisplayUnits|CoolingThresholdTemperature<br>CurrentRelativeHumidity<br>HeatingThresholdTemperature<br>Name<br>TargetRelativeHumidity|
 |Valve|Active<br>InUse<br>ValveType|SetDuration<br>RemainingDuration<br>IsConfigured<br>ServiceLabelIndex<br>StatusFault<br>Name|
 |Window|CurrentPosition<br>TargetPosition<br>PositionState|Name<br>HoldPosition<br>ObstructionDetected|

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -230,7 +230,7 @@ void Network::processRequest(char *body, char *formData){
   
   String responseHead="HTTP/1.1 200 OK\r\nContent-type: text/html\r\n";
   
-  String responseBody="<html><head><style>"
+  String responseBody="<html><meta charset=\"utf-8\"><head><style>"
                         "p{font-size:300%; margin:1em}"
                         "label{font-size:300%; margin:1em}"
                         "input{font-size:250%; margin:1em}"


### PR DESCRIPTION
Specify the charset as UTF-8 so that it will display the Non-English WiFi name in the configuration process correctly.
I tried in my Chinese WiFi name, and it works well.