### PR TITLE
Add PlatformIO compatibility

### DIFF
--- a/src/Settings.h
+++ b/src/Settings.h
@@ -27,7 +27,7 @@
  
 // USER-DEFINED SETTINGS AND REFERENCE ENUMERATION CLASSES
 
-#include <core_version.h>
+#include <esp_arduino_version.h>
 
 #pragma once
 


### PR DESCRIPTION
As discused in https://github.com/HomeSpan/HomeSpan/pull/374 in comment https://github.com/HomeSpan/HomeSpan/pull/374#issuecomment-1236348925 this replaces:
`#include <core_version.h>`
with 
`#include <esp_arduino_version.h>`