### PR TITLE
Preventing possibility of buffer overwrite.

### DIFF
--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -490,7 +490,7 @@ class SpanCharacteristic{
         return(String(c));        
       case FORMAT::STRING:
       case FORMAT::DATA:
-        sprintf(c,"\"%s\"",u.STRING);
+        sprintf(c,"\"%.61s\"",u.STRING); // Truncating string to 61 chars.
         return(String(c));        
     } // switch
     return(String());       // included to prevent compiler warnings


### PR DESCRIPTION
If `u.STRING` is larger than 63 chars, this will cause a buffer overwrite issue.
Dunno if you want to treat this as a CVE or not, as I don't know if you check the string's length somewhere else.