### PR TITLE
Moved vTaskDelay(5) from pollTask() to homeSpan.autoPoll()

### DIFF
--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -304,9 +304,6 @@ void Span::pollTask() {
   }
 
   statusLED->check();
-
-  if(pollTaskHandle)
-    vTaskDelay(5);
     
 } // poll
 

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -356,7 +356,7 @@ class Span{
   Span& setVerboseWifiReconnect(bool verbose=true){verboseWifiReconnect=verbose;return(*this);}
 
   void autoPoll(uint32_t stackSize=8192, uint32_t priority=1, uint32_t cpu=0){     // start pollTask()
-    xTaskCreateUniversal([](void *parms){for(;;)homeSpan.pollTask();}, "pollTask", stackSize, NULL, priority, &pollTaskHandle, cpu);
+    xTaskCreateUniversal([](void *parms){for(;;)homeSpan.pollTask();vTaskDelay(5);}, "pollTask", stackSize, NULL, priority, &pollTaskHandle, cpu);
     LOG0("\n*** AutoPolling Task started with priority=%d\n\n",uxTaskPriorityGet(pollTaskHandle)); 
   }
 


### PR DESCRIPTION
Adding the vTaskDelay(5) to the code that spawns the separate task is more consistent with how Arduino-ESP32 spawns the main loop() task.