### PR TITLE
Add function to read out the stack usage in the autopoll function

### DIFF
--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -400,6 +400,10 @@ class Span{
     LOG0("\n*** AutoPolling Task started with priority=%d\n\n",uxTaskPriorityGet(pollTaskHandle)); 
   }
 
+  uint32_t getAutoPollMinFreeStack(){
+     return pollTaskHandle != NULL ? uxTaskGetStackHighWaterMark(pollTaskHandle) : 0;
+  }
+
   Span& setTimeServerTimeout(uint32_t tSec){webLog.waitTime=tSec*1000;return(*this);}    // sets wait time (in seconds) for optional web log time server to connect
  
   [[deprecated("Please use reserveSocketConnections(n) method instead.")]]


### PR DESCRIPTION
It would be nice to have a possibility to get the stack usages of the autopoll function. Another option would be to return the taskhandle from the autoPoll() function.
