### PR TITLE
Adding TLS support for weblogs

### DIFF
--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -2,6 +2,13 @@
 
 HomeSpan includes a variety of message logs with different levels of verbosity, as well built-in methods to create your own log messages and web logs.
 
+1. [HomeSpan Log Message](homespan-log-messages)
+1. [User-Defined Log Messages](user-defined-log-messages)
+1. [Web Logging](web-logging)
+   1. [Custom Style Sheets (CSS)](custom-style-sheets-css)
+   1. [Adding User-Defined Data and/or Custom HTML](adding-user-defined-data-and-or-custom-html)
+   1. [Enabling TLS Web Logs](enabling-tls-web-logs)
+
 ## HomeSpan Log Messages
 
 HomeSpan log messages are typically output directly to the Arduino Serial Monitor with three possible levels of verbosity:
@@ -104,6 +111,15 @@ To embed this custom HTML text in the Web Log, call `homeSpan.setWebLogCallback(
 
 Note that *r* is being passed as a reference and already includes all the HTML text the Web Log has produced to set up the page and create the initial table.  You should therefore *extend* this String using  `+=`.  Do not simple assign this variable to a new String with `=` or you will overwrite all the HTML already produced!
  
+### Enabling TLS Web Logs
+When Web Logs are enabled, HomeSpan shares the same web server instance to serve HomeKit controllers and web logs. Web logs are accessed via HTTP only, providing no security. If sensitive information is expected to be logged, web logs should be accessed via HTTPS, using Transport Security Layer (TLS).
+
+To enable TLS with default configuration, call `enableTLS()` prior to calling `homeSpan.begin()`. HomeSpan will then attempt to generate an ECDSA keypair and self-signed certificate using NIST P-256 curve. Since the RSA algorithm requires larger keys, the use of Elliptic Curve Cryptography (ECC) is preferred as it uses smaller key sizes while providing the same security strength. RSA keypairs are certificates are not currently supported.
+
+A new EC keypair and ECDSA certificate will be created after each boot unless developers want to use their own, using `enableTLS(port, ec_private_key_pem, ec_server_cert_pem)`. This ensures that no HomeSpan device ends up with the same keypair which would be considered a security vulnerability. HomeSpan developers should generate their own keypair and certificate, PEM-encoded, and pass their values to `enableTLS(port, ec_private_key_pem, ec_server_cert_pem)`. **Never log the private key.**
+
+When TLS is configured and web logs are accessed via the non-HTTPS port, HomeSpan will issue an HTTP 301 (Permanently Moved) to the HTTPS port, which defaults to 443.
+
 ---
 
 [↩️](../README.md) Back to the Welcome page

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -200,6 +200,17 @@ The following **optional** `homeSpan` methods enable additional features and pro
   * returns the version of a HomeSpan sketch, as set using `void setSketchVersion(const char *sVer)`, or "n/a" if not set
   * can by called from anywhere in a sketch
 
+* `Span& enableTLS()`
+  * Enable TLS (HTTPS) for weblogs, instead of unsecure (non-TLS / HTTP) connections. If weblogs have been enabled for a specific URI, end users will be redirected to the HTTPS port.
+  * Defaults to using port 443 (default HTTPS port)
+  * New ECDSA certificate generated at each reboot
+* `Span& enableTLS(u_int16_t port = 443, const char *ec_private_key_pem = NULL, const char *ec_server_cert_pem = NULL)`
+  * Enable TLS (HTTPS) for weblogs, instead of unsecure (non-TLS / HTTP) connections. If weblogs have been enabled for a specific URI, end users will be redirected to the HTTPS port.
+  * **port** Port for HTTPS connections. Defaults to 443 (default HTTPS port)
+   * **ec_private_key_pem** ECC private key, in PEM format, to use for HTTPS. NOTE: RSA keys are not supported given their larger key size for similar security strength. A 256-bit ECC key provides similar security strength as an RSA 4096-bit key. When NULL, HomeSpan will attempt to generate its own ECC keypair at EACH REBOOT.
+   * **ec_server_cert_pem** Matching EC certificate for the primate key. Keypair validation is not done.  When NULL, HomeSpan will attempt to generate its own ECDSA with NIST P-256 certificate at EACH REBOOT.
+   
+
 * `Span& enableWebLog(uint16_t maxEntries, const char *timeServerURL, const char *timeZone, const char *logURL)`
   * enables a rolling Web Log that displays the most recent *maxEntries* entries created by the user with the `WEBLOG()` macro.  Parameters, and their default values if unspecified, are as follows:
     * *maxEntries* - maximum number of (most recent) entries to save.  If unspecified, defaults to 0, in which case the Web Log will only display status without any log entries

--- a/src/HAP.h
+++ b/src/HAP.h
@@ -126,7 +126,7 @@ struct HAPClient {
   int getCharacteristicsURL(char *urlBuf);     // GET /characteristics (HAP Section 6.7.4)  
   int putCharacteristicsURL(char *json);       // PUT /characteristics (HAP Section 6.7.2)
   int putPrepareURL(char *json);               // PUT /prepare (HAP Section 6.7.2.4)
-  int getStatusURL();                          // GET / status (an optional, non-HAP feature)
+  int getStatusURL(httpd_req_t *req = NULL); // GET / status (an optional, non-HAP feature)
 
   void tlvRespond();                                                // respond to client with HTTP OK header and all defined TLV data records (those with length>0)
   void sendEncrypted(char *body, uint8_t *dataBuf, int dataLen);    // send client complete ChaCha20-Poly1305 encrypted HTTP mesage comprising a null-terminated 'body' and 'dataBuf' with 'dataLen' bytes

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -350,6 +350,7 @@ class Span{
   Span& setSerialInputDisable(boolean val){serialInputDisabled=val;return(*this);}       // sets whether serial input is disabled (true) or enabled (false)
   boolean getSerialInputDisable(){return(serialInputDisabled);}                          // returns true if serial input is disabled, or false if serial input in enabled
   Span& reserveSocketConnections(uint8_t n){maxConnections-=n;return(*this);}            // reserves n socket connections *not* to be used for HAP
+  Span& setHostNameBase(const char *base){hostNameBase=base;return(*this);}              // sets the hostName base prior to begin(). Required when enabling TLS for certificate generation
   Span& setHostNameSuffix(const char *suffix){hostNameSuffix=suffix;return(*this);}      // sets the hostName suffix to be used instead of the 6-byte AccessoryID
   Span& setPortNum(uint16_t port){tcpPortNum=port;return(*this);}                        // sets the TCP port number to use for communications between HomeKit and HomeSpan
   Span& setQRID(const char *id);                                                         // sets the Setup ID for optional pairing with a QR Code


### PR DESCRIPTION
This is a [draft pull request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) btw..

Logs can contain sensitive data.
When logs are visible via the network (HTTP), logs fly in clear text on the wire. Not good.

This is a first stab at getting some feedback from @HomeSpan maintainer. I think it is somewhat very easy to use, if you look at the updated `Logging.md`.

There are still some unknowns I would like you feedback on. Look at the **TODO** comment block in `generate_certificate()` of `HomeSpan.cpp`.

The idea is that HomeSpan users should provide their own certificate & private key. Until they do, HomeSpan will generate a new keypair/certificate at each reboot. A bit annoying for developers and browser security warnings, but this is on purpose to force them to use their own. Should they decide not to use their own certificates, then HomeSpan still keep weblogs secure by not reusing the same keypair for multiple devices.

Only ECDSA is supported because keys are smaller than RSA while providing the same level of protection.

Awaiting feedback!