### PR TITLE
Add Improv WiFi Serial Protocol Support

### DIFF
--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -222,7 +222,7 @@ void Span::pollTask() {
   if(!serialInputDisabled && Serial.available()){
     readSerial(cBuf,64);
 
-    if(strncmp(cBuf, "IMPROV", 6) == 0) {
+    if(strncmp(cBuf, "IMPROV", 6) == 0) { // check for an Improv-Serial command, see https://www.improv-wifi.com/serial/
       processImprovCommand(cBuf, this);
     } else {
       processSerialCommand(cBuf);

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -223,7 +223,7 @@ void Span::pollTask() {
     readSerial(cBuf,64);
 
     if(strncmp(cBuf, "IMPROV", 6) == 0) {
-      processImprovCommand(cBuf);
+      processImprovCommand(cBuf, this);
     } else {
       processSerialCommand(cBuf);
     }

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -1159,6 +1159,12 @@ void Span::getWebLog(void (*f)(const char *, void *), void *user_data){
 
 ///////////////////////////////
 
+const char* Span::getDisplayName(){
+  return(this->displayName);
+}
+
+///////////////////////////////
+
 void Span::resetStatus(){
   if(strlen(network.wifiData.ssid)==0)
     STATUS_UPDATE(start(LED_WIFI_NEEDED),HS_WIFI_NEEDED)

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -221,7 +221,12 @@ void Span::pollTask() {
   
   if(!serialInputDisabled && Serial.available()){
     readSerial(cBuf,64);
-    processSerialCommand(cBuf);
+
+    if(strncmp(cBuf, "IMPROV", 6) == 0) {
+      processImprovCommand(cBuf);
+    } else {
+      processSerialCommand(cBuf);
+    }
   }
 
   WiFiClient newClient;

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -365,6 +365,8 @@ class Span{
   Span& setWebLogCallback(void (*f)(String &)){weblogCallback=f;return(*this);} 
   void getWebLog(void (*f)(const char *, void *), void *);
 
+  const char* getDisplayName();
+
   Span& setVerboseWifiReconnect(bool verbose=true){verboseWifiReconnect=verbose;return(*this);}
 
   Span& setRebootCallback(void (*f)(uint8_t),uint32_t t=DEFAULT_REBOOT_CALLBACK_TIME){rebootCallback=f;rebootCallbackTime=t;return(*this);}

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -298,6 +298,8 @@ class Span{
              
   void poll();                                  // calls pollTask() with some error checking
   void processSerialCommand(const char *c);     // process command 'c' (typically from readSerial, though can be called with any 'c')
+  void processImprovCommand(const char *c);     // process Improv-Serial command 'c'
+  void Span::handleImprovCommand(improv::ImprovCommand cmd);
   
   boolean updateDatabase(boolean updateMDNS=true);   // updates HAP Configuration Number and Loop vector; if updateMDNS=true and config number has changed, re-broadcasts MDNS 'c#' record; returns true if config number changed
   boolean deleteAccessory(uint32_t aid);             // deletes Accessory with matching aid; returns true if found, else returns false 

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -271,7 +271,6 @@ class Span{
   void checkConnect();                          // check WiFi connection; connect if needed
   void commandMode();                           // allows user to control and reset HomeSpan settings with the control button
   void resetStatus();                           // resets statusLED and calls statusCallback based on current HomeSpan status
-  void reboot();                                // reboots device
 
   void printfAttributes(int flags=GET_VALUE|GET_META|GET_PERMS|GET_TYPE|GET_DESC);   // writes Attributes JSON database to hapOut stream
   
@@ -295,11 +294,11 @@ class Span{
              const char *displayName=DEFAULT_DISPLAY_NAME,
              const char *hostNameBase=DEFAULT_HOST_NAME,
              const char *modelName=DEFAULT_MODEL_NAME);        
-             
+
+  void reboot();                                // reboots device
   void poll();                                  // calls pollTask() with some error checking
   void processSerialCommand(const char *c);     // process command 'c' (typically from readSerial, though can be called with any 'c')
-  void processImprovCommand(const char *c);     // process Improv-Serial command 'c'
-  void Span::handleImprovCommand(improv::ImprovCommand cmd);
+  void processImprovCommand(const char *c, Span* span);     // process Improv-Serial command 'c'
   
   boolean updateDatabase(boolean updateMDNS=true);   // updates HAP Configuration Number and Loop vector; if updateMDNS=true and config number has changed, re-broadcasts MDNS 'c#' record; returns true if config number changed
   boolean deleteAccessory(uint32_t aid);             // deletes Accessory with matching aid; returns true if found, else returns false 

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -1,0 +1,296 @@
+#include "improv.h"
+#include "HomeSpan.h"
+
+using namespace Utils;
+using namespace improv;
+
+void Span::processImprovCommand(const char *c){
+  
+  uint8_t len = c[8] + 10;
+  // Copy the const char *c from the argument into a new character array
+  char buffer[len];
+  strcpy(buffer, c);
+  buffer[len-1] = c[len-1]; // Copy the checksum bit since it falls after the null terminator
+
+  Serial.print("Command: ");
+  for (size_t i = 0; i < len; i++) {
+    Serial.print("0x");
+    Serial.print(c[i] < 16 ? "0" : "");
+    Serial.print(c[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.println();
+
+  Serial.println("Processing Improv Command " + String(buffer) + " length " + strlen(buffer));
+  Serial.print("Command: ");
+  for (size_t i = 0; i < len; i++) {
+    Serial.print("0x");
+    Serial.print(buffer[i] < 16 ? "0" : "");
+    Serial.print(buffer[i], HEX);
+    Serial.print(" ");
+  }
+
+  Serial.println();
+  Serial.println("Length " + String(len) + " char ");
+  Serial.println(buffer[len - 1], HEX);
+  Serial.println("Onwards...");
+
+  improv::parse_improv_serial_byte(len - 1, buffer[len - 1], (uint8_t *)c, [&](ImprovCommand command) {
+    improv::handleImprovCommand(command);
+    return true;
+  }, [&](Error error) {
+    Serial.println("Error parsing Improv command");
+  });
+} // Span::processImprovCommand
+
+
+namespace improv {
+
+void handleImprovCommand(improv::ImprovCommand cmd) {
+  switch (cmd.command) {
+    case Command::WIFI_SETTINGS:
+      Serial.println("WiFi Settings: ");
+      Serial.print(cmd.ssid.c_str());
+      Serial.print(" ");
+      Serial.println(cmd.password.c_str());
+      //Span::setWifiCredentials(cmd.ssid.c_str(), cmd.password.c_str());
+      break;
+    case Command::GET_CURRENT_STATE:
+      if ((WiFi.status() == WL_CONNECTED)) {
+        sendImprovState(improv::State::STATE_PROVISIONED);
+        //std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_CURRENT_STATE, getLocalUrl(), false);
+        //send_response(data);
+
+      } else {
+        sendImprovState(improv::State::STATE_AUTHORIZED);
+      }
+      break;
+    case Command::GET_DEVICE_INFO:
+      {
+        Serial.println("Get Device Info");
+        std::vector<std::string> infos = {
+          // Firmware name
+          "HomeSpan",
+          // Firmware version
+          "1.0.0",
+          // Hardware chip/variant
+          "ESP32",
+          // Device name
+          "HomeSpanDevice"
+        };
+        std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
+        improv::sendImprovResponse(data);
+        break;
+      }
+    case Command::GET_WIFI_NETWORKS:
+      getAvailableWifiNetworks();
+      break;
+    case Command::BAD_CHECKSUM:
+      Serial.println("Bad Checksum");
+      break;
+    case Command::UNKNOWN:
+      Serial.println("Unknown");
+      break;
+  }
+}
+
+void getAvailableWifiNetworks() {
+  int networkNum = WiFi.scanNetworks();
+
+  for (int id = 0; id < networkNum; ++id) { 
+    std::vector<uint8_t> data = improv::build_rpc_response(
+            improv::GET_WIFI_NETWORKS, {WiFi.SSID(id), String(WiFi.RSSI(id)), (WiFi.encryptionType(id) == WIFI_AUTH_OPEN ? "NO" : "YES")}, false);
+    improv::sendImprovResponse(data);
+    delay(1);
+  }
+  //final response
+  std::vector<uint8_t> data =
+          improv::build_rpc_response(improv::GET_WIFI_NETWORKS, std::vector<std::string>{}, false);
+  improv::sendImprovResponse(data);
+}
+
+void sendImprovState(improv::State state) {
+  std::vector<uint8_t> data = {'I', 'M', 'P', 'R', 'O', 'V'};
+  data.resize(11);
+  data[6] = improv::IMPROV_SERIAL_VERSION;
+  data[7] = improv::TYPE_CURRENT_STATE;
+  data[8] = 1;
+  data[9] = state;
+
+  uint8_t checksum = 0x00;
+  for (uint8_t d : data)
+    checksum += d;
+  data[10] = checksum;
+  Serial.println("Writing " + String(data.size()) + " bytes to Improv");
+
+  Serial.write(data.data(), data.size());
+} // sendImprovState
+
+void sendImprovResponse(std::vector<uint8_t> &response) {
+  std::vector<uint8_t> data = {'I', 'M', 'P', 'R', 'O', 'V'};
+  data.resize(9);
+  data[6] = improv::IMPROV_SERIAL_VERSION;
+  data[7] = improv::TYPE_RPC_RESPONSE;
+  data[8] = response.size();
+  data.insert(data.end(), response.begin(), response.end());
+
+  uint8_t checksum = 0x00;
+  for (uint8_t d : data)
+    checksum += d;
+  data.push_back(checksum);
+
+  Serial.write(data.data(), data.size());
+
+  Serial.println("Wrote ");
+  for (size_t i = 0; i < data.size(); i++) {
+    Serial.print("0x");
+    Serial.print(data[i] < 16 ? "0" : "");
+    Serial.print(data[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.println();
+}
+
+// From https://github.com/improv-wifi/sdk-cpp/blob/main/src/improv.cpp
+ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum) {
+  return parse_improv_data(data.data(), data.size(), check_checksum);
+} // parse_improv_data
+
+ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum) {
+  ImprovCommand improv_command;
+  Command command = (Command) data[0];
+  uint8_t data_length = data[1];
+
+  if (data_length != length - 2 - check_checksum) {
+    improv_command.command = UNKNOWN;
+    return improv_command;
+  }
+
+  if (check_checksum) {
+    uint8_t checksum = data[length - 1];
+
+    uint32_t calculated_checksum = 0;
+    for (uint8_t i = 0; i < length - 1; i++) {
+      calculated_checksum += data[i];
+    }
+
+    if ((uint8_t) calculated_checksum != checksum) {
+      improv_command.command = BAD_CHECKSUM;
+      return improv_command;
+    }
+  }
+
+  if (command == WIFI_SETTINGS) {
+    uint8_t ssid_length = data[2];
+    uint8_t ssid_start = 3;
+    size_t ssid_end = ssid_start + ssid_length;
+
+    uint8_t pass_length = data[ssid_end];
+    size_t pass_start = ssid_end + 1;
+    size_t pass_end = pass_start + pass_length;
+
+    std::string ssid(data + ssid_start, data + ssid_end);
+    std::string password(data + pass_start, data + pass_end);
+    return {.command = command, .ssid = ssid, .password = password};
+  }
+
+  improv_command.command = command;
+  return improv_command;
+} // parse_improv_data
+
+bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
+                              std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error) {
+  if (position == 0)
+    return byte == 'I';
+  if (position == 1)
+    return byte == 'M';
+  if (position == 2)
+    return byte == 'P';
+  if (position == 3)
+    return byte == 'R';
+  if (position == 4)
+    return byte == 'O';
+  if (position == 5)
+    return byte == 'V';
+
+  if (position == 6)
+    return byte == IMPROV_SERIAL_VERSION;
+
+  if (position <= 8)
+    return true;
+
+  uint8_t type = buffer[7];
+  uint8_t data_len = buffer[8];
+
+  if (position <= 8 + data_len)
+    return true;
+
+  if (position == 8 + data_len + 1) {
+    uint8_t checksum = 0x00;
+    for (size_t i = 0; i < position; i++)
+      checksum += buffer[i];
+
+    Serial.println("Checksum: " + String(checksum) + " Byte: " + String(byte));
+    if (checksum != byte) {
+      on_error(ERROR_INVALID_RPC);
+      return false;
+    }
+
+    if (type == TYPE_RPC) {
+      auto command = parse_improv_data(&buffer[9], data_len, false);
+      return callback(command);
+    }
+  }
+
+  return false;
+} // parse_improv_serial_byte
+
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum, bool add_checksum) {
+  std::vector<uint8_t> out;
+  uint32_t length = 0;
+  out.push_back(command);
+  for (const auto &str : datum) {
+    uint8_t len = str.length();
+    length += len + 1;
+    out.push_back(len);
+    out.insert(out.end(), str.begin(), str.end());
+  }
+  out.insert(out.begin() + 1, length);
+
+  if (add_checksum) {
+    uint32_t calculated_checksum = 0;
+
+    for (uint8_t byte : out) {
+      calculated_checksum += byte;
+    }
+    out.push_back(calculated_checksum);
+  }
+  return out;
+} // build_rpc_response
+
+#ifdef ARDUINO
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum) {
+  std::vector<uint8_t> out;
+  uint32_t length = 0;
+  out.push_back(command);
+  for (const auto &str : datum) {
+    uint8_t len = str.length();
+    length += len;
+    out.push_back(len);
+    out.insert(out.end(), str.begin(), str.end());
+  }
+  out.insert(out.begin() + 1, length);
+
+  if (add_checksum) {
+    uint32_t calculated_checksum = 0;
+
+    for (uint8_t byte : out) {
+      calculated_checksum += byte;
+    }
+    out.push_back(calculated_checksum);
+  }
+  return out;
+} // build_rpc_response
+#endif  // ARDUINO
+
+}  // namespace improv

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -81,11 +81,11 @@ void handleImprovCommand(improv::ImprovCommand cmd, Span* span) {
           // Firmware name
           "HomeSpan",
           // Firmware version
-          "1.0.0",
+          HOMESPAN_VERSION,
           // Hardware chip/variant
           "ESP32",
           // Device name
-          "HomeSpanDevice"
+          span->getDisplayName(),
         };
         std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_DEVICE_INFO, infos, false);
         improv::sendImprovResponse(data);

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -50,6 +50,7 @@ void handleImprovCommand(improv::ImprovCommand cmd, Span* span) {
       if (connectWifi(cmd.ssid.c_str(), cmd.password.c_str())) {
         sendImprovState(improv::State::STATE_PROVISIONED);
         std::vector<std::string> infos; // Empty vector, we could put an HTTP URL here as the next step for the user if we had one
+                                        // IDEA: We could link to a page that will render the QR code for the user to scan
         std::vector<uint8_t> data = improv::buildRPCResponse(improv::WIFI_SETTINGS, infos, false);
         improv::sendImprovResponse(data);
 

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -4,7 +4,9 @@
 using namespace Utils;
 using namespace improv;
 
-void Span::processImprovCommand(const char *c){
+#define MAX_ATTEMPTS_WIFI_CONNECTION 10
+
+void Span::processImprovCommand(const char *c, Span* span){
   
   uint8_t len = c[8] + 10;
   // Copy the const char *c from the argument into a new character array
@@ -12,55 +14,47 @@ void Span::processImprovCommand(const char *c){
   strcpy(buffer, c);
   buffer[len-1] = c[len-1]; // Copy the checksum bit since it falls after the null terminator
 
-  Serial.print("Command: ");
-  for (size_t i = 0; i < len; i++) {
-    Serial.print("0x");
-    Serial.print(c[i] < 16 ? "0" : "");
-    Serial.print(c[i], HEX);
-    Serial.print(" ");
-  }
-  Serial.println();
-
-  Serial.println("Processing Improv Command " + String(buffer) + " length " + strlen(buffer));
-  Serial.print("Command: ");
-  for (size_t i = 0; i < len; i++) {
-    Serial.print("0x");
-    Serial.print(buffer[i] < 16 ? "0" : "");
-    Serial.print(buffer[i], HEX);
-    Serial.print(" ");
-  }
-
-  Serial.println();
-  Serial.println("Length " + String(len) + " char ");
-  Serial.println(buffer[len - 1], HEX);
-  Serial.println("Onwards...");
-
   improv::parse_improv_serial_byte(len - 1, buffer[len - 1], (uint8_t *)c, [&](ImprovCommand command) {
-    improv::handleImprovCommand(command);
+    improv::handleImprovCommand(command, span);
     return true;
   }, [&](Error error) {
-    Serial.println("Error parsing Improv command");
+    LOG0("Error parsing Improv command");
   });
 } // Span::processImprovCommand
 
 
 namespace improv {
 
-void handleImprovCommand(improv::ImprovCommand cmd) {
-  switch (cmd.command) {
+void handleImprovCommand(improv::ImprovCommand cmd, Span* span) {
+  switch(cmd.command) {
     case Command::WIFI_SETTINGS:
       Serial.println("WiFi Settings: ");
       Serial.print(cmd.ssid.c_str());
       Serial.print(" ");
       Serial.println(cmd.password.c_str());
-      //Span::setWifiCredentials(cmd.ssid.c_str(), cmd.password.c_str());
-      break;
-    case Command::GET_CURRENT_STATE:
-      if ((WiFi.status() == WL_CONNECTED)) {
-        sendImprovState(improv::State::STATE_PROVISIONED);
-        //std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_CURRENT_STATE, getLocalUrl(), false);
-        //send_response(data);
 
+      // Attempt to use our credentials so we can see if they work
+      if (connectWifi(cmd.ssid.c_str(), cmd.password.c_str())) {
+        sendImprovState(improv::State::STATE_PROVISIONED);
+        std::vector<std::string> infos; // Empty vector, we could put an HTTP URL here as the next step for the user if we had one
+        std::vector<uint8_t> data = improv::build_rpc_response(improv::WIFI_SETTINGS, infos, false);
+        improv::sendImprovResponse(data);
+
+        span->setWifiCredentials(cmd.ssid.c_str(), cmd.password.c_str()); // Save credentials and reboot
+        delay(1000); // Give the serial on the other end a moment to process
+        span->reboot();
+      } else {
+        sendImprovState(improv::State::STATE_STOPPED);
+        improv::sendImprovError(improv::Error::ERROR_UNABLE_TO_CONNECT);
+      }
+      break;
+
+    case Command::GET_CURRENT_STATE:
+      if((WiFi.status() == WL_CONNECTED)) {
+        sendImprovState(improv::State::STATE_PROVISIONED);
+        std::vector<std::string> infos; // Empty vector, we could put an HTTP URL here as the next step for the user if we had one
+        std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_CURRENT_STATE, infos, false);
+        improv::sendImprovResponse(data);
       } else {
         sendImprovState(improv::State::STATE_AUTHORIZED);
       }
@@ -94,10 +88,31 @@ void handleImprovCommand(improv::ImprovCommand cmd) {
   }
 }
 
+bool connectWifi(const char *ssid, const char *pwd) {
+  uint8_t attempts = 0;
+
+  WiFi.begin(ssid, pwd);
+  LOG2("Attempting to connect to WiFi SSID %s", ssid);
+
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(1000);
+    LOG2("Attempting to connect to WiFi SSID %s, attempt #%s", ssid, String(attempts));
+    if (attempts > MAX_ATTEMPTS_WIFI_CONNECTION) {
+      LOG0("Failed to connect to WiFi");
+      WiFi.disconnect();
+      return false;
+    }
+    attempts++;
+  }
+
+  LOG0("Successfully connected to WiFi SSID %s", ssid);
+  return true;
+} // connectWifi
+
 void getAvailableWifiNetworks() {
   int networkNum = WiFi.scanNetworks();
 
-  for (int id = 0; id < networkNum; ++id) { 
+  for(int id = 0; id < networkNum; ++id) { 
     std::vector<uint8_t> data = improv::build_rpc_response(
             improv::GET_WIFI_NETWORKS, {WiFi.SSID(id), String(WiFi.RSSI(id)), (WiFi.encryptionType(id) == WIFI_AUTH_OPEN ? "NO" : "YES")}, false);
     improv::sendImprovResponse(data);
@@ -118,13 +133,37 @@ void sendImprovState(improv::State state) {
   data[9] = state;
 
   uint8_t checksum = 0x00;
+  for(uint8_t d : data)
+    checksum += d;
+  data[10] = checksum;
+
+  Serial.write(data.data(), data.size());
+  
+  Serial.println("Wrote ");
+  for(size_t i = 0; i < data.size(); i++) {
+    Serial.print("0x");
+    Serial.print(data[i] < 16 ? "0" : "");
+    Serial.print(data[i], HEX);
+    Serial.print(" ");
+  }
+  Serial.println();
+} // sendImprovState
+
+void sendImprovError(improv::Error error) {
+  std::vector<uint8_t> data = {'I', 'M', 'P', 'R', 'O', 'V'};
+  data.resize(11);
+  data[6] = improv::IMPROV_SERIAL_VERSION;
+  data[7] = improv::TYPE_ERROR_STATE;
+  data[8] = 1;
+  data[9] = error;
+
+  uint8_t checksum = 0x00;
   for (uint8_t d : data)
     checksum += d;
   data[10] = checksum;
-  Serial.println("Writing " + String(data.size()) + " bytes to Improv");
 
   Serial.write(data.data(), data.size());
-} // sendImprovState
+}
 
 void sendImprovResponse(std::vector<uint8_t> &response) {
   std::vector<uint8_t> data = {'I', 'M', 'P', 'R', 'O', 'V'};
@@ -135,14 +174,14 @@ void sendImprovResponse(std::vector<uint8_t> &response) {
   data.insert(data.end(), response.begin(), response.end());
 
   uint8_t checksum = 0x00;
-  for (uint8_t d : data)
+  for(uint8_t d : data)
     checksum += d;
   data.push_back(checksum);
 
   Serial.write(data.data(), data.size());
 
   Serial.println("Wrote ");
-  for (size_t i = 0; i < data.size(); i++) {
+  for(size_t i = 0; i < data.size(); i++) {
     Serial.print("0x");
     Serial.print(data[i] < 16 ? "0" : "");
     Serial.print(data[i], HEX);
@@ -161,26 +200,26 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_c
   Command command = (Command) data[0];
   uint8_t data_length = data[1];
 
-  if (data_length != length - 2 - check_checksum) {
+  if(data_length != length - 2 - check_checksum) {
     improv_command.command = UNKNOWN;
     return improv_command;
   }
 
-  if (check_checksum) {
+  if(check_checksum) {
     uint8_t checksum = data[length - 1];
 
     uint32_t calculated_checksum = 0;
-    for (uint8_t i = 0; i < length - 1; i++) {
+    for(uint8_t i = 0; i < length - 1; i++) {
       calculated_checksum += data[i];
     }
 
-    if ((uint8_t) calculated_checksum != checksum) {
+    if((uint8_t) calculated_checksum != checksum) {
       improv_command.command = BAD_CHECKSUM;
       return improv_command;
     }
   }
 
-  if (command == WIFI_SETTINGS) {
+  if(command == WIFI_SETTINGS) {
     uint8_t ssid_length = data[2];
     uint8_t ssid_start = 3;
     size_t ssid_end = ssid_start + ssid_length;
@@ -200,43 +239,43 @@ ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_c
 
 bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
                               std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error) {
-  if (position == 0)
+  if(position == 0)
     return byte == 'I';
-  if (position == 1)
+  if(position == 1)
     return byte == 'M';
-  if (position == 2)
+  if(position == 2)
     return byte == 'P';
-  if (position == 3)
+  if(position == 3)
     return byte == 'R';
-  if (position == 4)
+  if(position == 4)
     return byte == 'O';
-  if (position == 5)
+  if(position == 5)
     return byte == 'V';
 
-  if (position == 6)
+  if(position == 6)
     return byte == IMPROV_SERIAL_VERSION;
 
-  if (position <= 8)
+  if(position <= 8)
     return true;
 
   uint8_t type = buffer[7];
   uint8_t data_len = buffer[8];
 
-  if (position <= 8 + data_len)
+  if(position <= 8 + data_len)
     return true;
 
-  if (position == 8 + data_len + 1) {
+  if(position == 8 + data_len + 1) {
     uint8_t checksum = 0x00;
-    for (size_t i = 0; i < position; i++)
+    for(size_t i = 0; i < position; i++)
       checksum += buffer[i];
 
     Serial.println("Checksum: " + String(checksum) + " Byte: " + String(byte));
-    if (checksum != byte) {
+    if(checksum != byte) {
       on_error(ERROR_INVALID_RPC);
       return false;
     }
 
-    if (type == TYPE_RPC) {
+    if(type == TYPE_RPC) {
       auto command = parse_improv_data(&buffer[9], data_len, false);
       return callback(command);
     }
@@ -249,7 +288,7 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::
   std::vector<uint8_t> out;
   uint32_t length = 0;
   out.push_back(command);
-  for (const auto &str : datum) {
+  for(const auto &str : datum) {
     uint8_t len = str.length();
     length += len + 1;
     out.push_back(len);
@@ -257,10 +296,10 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::
   }
   out.insert(out.begin() + 1, length);
 
-  if (add_checksum) {
+  if(add_checksum) {
     uint32_t calculated_checksum = 0;
 
-    for (uint8_t byte : out) {
+    for(uint8_t byte : out) {
       calculated_checksum += byte;
     }
     out.push_back(calculated_checksum);
@@ -273,7 +312,7 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<Strin
   std::vector<uint8_t> out;
   uint32_t length = 0;
   out.push_back(command);
-  for (const auto &str : datum) {
+  for(const auto &str : datum) {
     uint8_t len = str.length();
     length += len;
     out.push_back(len);
@@ -281,10 +320,10 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<Strin
   }
   out.insert(out.begin() + 1, length);
 
-  if (add_checksum) {
+  if(add_checksum) {
     uint32_t calculated_checksum = 0;
 
-    for (uint8_t byte : out) {
+    for(uint8_t byte : out) {
       calculated_checksum += byte;
     }
     out.push_back(calculated_checksum);

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -3,7 +3,7 @@
  * Jonathas Barbosa (https://github.com/jnthas/improv-wifi-demo)
  * Improv Wi-Fi (https://github.com/improv-wifi/sdk-cpp)
  ********************************************************************************/
-#include "improv.h"
+#include "Improv.h"
 #include "HomeSpan.h"
 
 using namespace Utils;

--- a/src/Improv.cpp
+++ b/src/Improv.cpp
@@ -1,7 +1,31 @@
 /*********************************************************************************
- * This code includes contributions from:
- * Jonathas Barbosa (https://github.com/jnthas/improv-wifi-demo)
- * Improv Wi-Fi (https://github.com/improv-wifi/sdk-cpp)
+ *  MIT License
+ *  
+ *  Copyright (c) 2020-2024 Gregg E. Berman
+ *  
+ *  https://github.com/HomeSpan/HomeSpan
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ * 
+ *  This code includes open-source contributions from:
+ *  Jonathas Barbosa (https://github.com/jnthas/improv-wifi-demo)
+ *  Improv Wi-Fi (https://github.com/improv-wifi/sdk-cpp)
  ********************************************************************************/
 #include "Improv.h"
 #include "HomeSpan.h"

--- a/src/Improv.h
+++ b/src/Improv.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include "HomeSpan.h"
 
 namespace improv {
 
@@ -73,10 +74,11 @@ std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::
 std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum = true);
 #endif  // ARDUINO
 
-void handleImprovCommand(improv::ImprovCommand cmd);
+void handleImprovCommand(improv::ImprovCommand cmd, Span* span);
 void sendImprovState(improv::State state);
 void sendImprovResponse(std::vector<uint8_t> &response);
-void sendImprovRPCResponse(std::vector<uint8_t> &response);
+void sendImprovError(improv::Error error);
 void getAvailableWifiNetworks();
+bool connectWifi(const char *ssid, const char *pwd);
 
 }  // namespace improv

--- a/src/Improv.h
+++ b/src/Improv.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif  // ARDUINO
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace improv {
+
+static const char *const SERVICE_UUID = "00467768-6228-2272-4663-277478268000";
+static const char *const STATUS_UUID = "00467768-6228-2272-4663-277478268001";
+static const char *const ERROR_UUID = "00467768-6228-2272-4663-277478268002";
+static const char *const RPC_COMMAND_UUID = "00467768-6228-2272-4663-277478268003";
+static const char *const RPC_RESULT_UUID = "00467768-6228-2272-4663-277478268004";
+static const char *const CAPABILITIES_UUID = "00467768-6228-2272-4663-277478268005";
+
+enum Error : uint8_t {
+  ERROR_NONE = 0x00,
+  ERROR_INVALID_RPC = 0x01,
+  ERROR_UNKNOWN_RPC = 0x02,
+  ERROR_UNABLE_TO_CONNECT = 0x03,
+  ERROR_NOT_AUTHORIZED = 0x04,
+  ERROR_UNKNOWN = 0xFF,
+};
+
+enum State : uint8_t {
+  STATE_STOPPED = 0x00,
+  STATE_AWAITING_AUTHORIZATION = 0x01,
+  STATE_AUTHORIZED = 0x02,
+  STATE_PROVISIONING = 0x03,
+  STATE_PROVISIONED = 0x04,
+};
+
+enum Command : uint8_t {
+  UNKNOWN = 0x00,
+  WIFI_SETTINGS = 0x01,
+  IDENTIFY = 0x02,
+  GET_CURRENT_STATE = 0x02,
+  GET_DEVICE_INFO = 0x03,
+  GET_WIFI_NETWORKS = 0x04,
+  BAD_CHECKSUM = 0xFF,
+};
+
+static const uint8_t CAPABILITY_IDENTIFY = 0x01;
+static const uint8_t IMPROV_SERIAL_VERSION = 1;
+
+enum ImprovSerialType : uint8_t {
+  TYPE_CURRENT_STATE = 0x01,
+  TYPE_ERROR_STATE = 0x02,
+  TYPE_RPC = 0x03,
+  TYPE_RPC_RESPONSE = 0x04
+};
+
+struct ImprovCommand {
+  Command command;
+  std::string ssid;
+  std::string password;
+};
+
+ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum = true);
+ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum = true);
+
+bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
+                              std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error);
+
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum,
+                                        bool add_checksum = true);
+#ifdef ARDUINO
+std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum = true);
+#endif  // ARDUINO
+
+void handleImprovCommand(improv::ImprovCommand cmd);
+void sendImprovState(improv::State state);
+void sendImprovResponse(std::vector<uint8_t> &response);
+void sendImprovRPCResponse(std::vector<uint8_t> &response);
+void getAvailableWifiNetworks();
+
+}  // namespace improv

--- a/src/Improv.h
+++ b/src/Improv.h
@@ -62,16 +62,16 @@ struct ImprovCommand {
   std::string password;
 };
 
-ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum = true);
-ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum = true);
+ImprovCommand parseImprovData(const std::vector<uint8_t> &data, bool check_checksum = true);
+ImprovCommand parseImprovData(const uint8_t *data, size_t length, bool check_checksum = true);
 
-bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
+bool parseImprovSerialByte(size_t position, uint8_t byte, const uint8_t *buffer,
                               std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error);
 
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<std::string> &datum,
+std::vector<uint8_t> buildRPCResponse(Command command, const std::vector<std::string> &datum,
                                         bool add_checksum = true);
 #ifdef ARDUINO
-std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum = true);
+std::vector<uint8_t> buildRPCResponse(Command command, const std::vector<String> &datum, bool add_checksum = true);
 #endif  // ARDUINO
 
 void handleImprovCommand(improv::ImprovCommand cmd, Span* span);


### PR DESCRIPTION
Long time listener, first time caller! Love the project, wondering if you'd like to include this thing I put together...

I haven't written any docs here since it's an unsolicited PR and I didn't want to do a lot of writing if you decided it wasn't a good fit for the project or want major changes; happy to write some docs if this is something you think is worth including.

**The Problem:**
I've been playing around with [rednblkx's HomeKey-ESP32](https://github.com/rednblkx/HomeKey-ESP32) project based on HomeSpan, which has a bit of an arduous setup process including installing and trying to troubleshoot a VSCode extension.

Lots of ESP projects like [WLED](https://install.wled.me/) use browser-based installers based on [ESP Web Tools](https://esphome.github.io/esp-web-tools/), which lets you flash and set up WiFi directly from the browser using web serial. I started a repo for handling building the binary for that project, but then I wanted it to be able to confirm the install and configure WiFi, which requires implementing the [Improv Wi-Fi standard](https://www.improv-wifi.com/) to contribute to either HomeSpan itself or to that project. I figured I'd try my luck here to see if you're interested.

**The Solution:**
I have a pass here at implementing Improv Wi-Fi serial support (sorry, my C++ is... rusty at best, it was never that great in the first place). Improv works by sending serial commands that start with "IMPROV1", so I tapped into the main loop serial command reader to detect those and pass them off to the Improv.cpp file for processing.

These classes handle:
- Responding to requests for device status (important when it comes to confirming install, or when you load up an ESP Web Tools instance)
- Returning the list of scanned WiFi networks to show in the ESP Web Tools UI
- Processing WiFi credentials and connecting

**The End Product:**
Once you have an image with the Improv stuff installed, you can go to any ESP Web Tools page (e.g. [their official demo](https://esphome.github.io/esp-web-tools/)) and configure/change WiFi.

I made a proof-of-concept [HomeSpan ESP Web Tools installer demo](https://mccahan.github.io/homespan-esp-webtools-demo/) (repo [here](https://github.com/mccahan/homespan-esp-webtools-demo)) that you can load up in a browser, flash a binary made using GitHub Actions, and configure WiFi straight from the browser.

That demo currently runs the 05-WorkingLED example, compiled in [GitHub Actions](https://github.com/mccahan/homespan-esp-webtools-demo/blob/main/.github/workflows/deploy-pages.yml) and pushed to GitHub pages. It compiles it, merges it the way web tools requires into a single binary, and serves it up for install directly from the browser.

![WebInstallDemo](https://github.com/HomeSpan/HomeSpan/assets/2308923/95bacf6d-30e3-4448-b78b-03e94a0e1fc5)

**Thing I Got Stuck On:**
Logging from within the improv class - LOG2 (etc) aren't defined on that scope, and apparently I can't just `::LOG2()` them based on how they're implemented? I can investigate more to get that debug logging in, right now it's just commented out.

**Future Idea:**
When you finish installing and setting up WiFi, ESP Web Tools allows you to return a URL, which it shows as a button on the ESP Web Tools screen. I was looking at setting this to link to a QR code generated so the user can just scan it to add to HomeKit, but that required touching some more stuff than I wanted to with this PR. But I do think that would make for a pretty slick setup process for projects.