### PR TITLE
Adding typedef to Characteristics enum values.

### DIFF
--- a/src/Span.h
+++ b/src/Span.h
@@ -475,7 +475,7 @@ namespace Service {
 // Macro to define Span Characteristic structures based on name of HAP Characteristic, default value, and min/max value (not applicable for STRING or BOOL which default to min=0, max=1)
 
 #define CREATE_CHAR(TYPE,HAPCHAR,DEFVAL,MINVAL,MAXVAL,...) \
-  struct HAPCHAR : SpanCharacteristic { __VA_OPT__(enum{) __VA_ARGS__ __VA_OPT__(};) HAPCHAR(TYPE val=DEFVAL, boolean nvsStore=false) : SpanCharacteristic {&hapChars.HAPCHAR} { init<TYPE>(val,nvsStore,MINVAL,MAXVAL); } };
+  struct HAPCHAR : SpanCharacteristic { __VA_OPT__(typedef enum{) __VA_ARGS__ __VA_OPT__(}HAPCHAR ## Enum_t;) HAPCHAR(TYPE val=DEFVAL, boolean nvsStore=false) : SpanCharacteristic {&hapChars.HAPCHAR} { init<TYPE>(val,nvsStore,MINVAL,MAXVAL); } };
 
 namespace Characteristic {
   


### PR DESCRIPTION
Re-spin of PR #839 that got accidently closed.

This PR allows defining a type to the Characteristics enum values that were added recently so they can be re-used as return type, such as returning the security alarm state itself rather than its integer value:
```
  Characteristic::SecuritySystemCurrentState::SecuritySystemCurrentStateEnum_t getState() {
    return partitionCurrentState->getVal<Characteristic::SecuritySystemCurrentState::SecuritySystemCurrentStateEnum_t>();
  }
```

Also allows better Intellisense help when hovering over enum values which now shows:
```
enum Characteristic::SecuritySystemCurrentState::SecuritySystemCurrentStateEnum_t::DISARMED = 3
```
or 
```
enum Characteristic::ContactSensorState::ContactSensorStateEnum_t::DETECTED = 0
```
instead of
```
enum Characteristic::SecuritySystemCurrentState::<unnamed>::DISARMED = 3
```
and
```
enum Characteristic::ContactSensorState::<unnamed>::DETECTED = 0
```