### PR TITLE
Adding typedef to Characteristics enum values.

### DIFF
--- a/src/Span.h
+++ b/src/Span.h
@@ -475,7 +475,7 @@ namespace Service {
 // Macro to define Span Characteristic structures based on name of HAP Characteristic, default value, and min/max value (not applicable for STRING or BOOL which default to min=0, max=1)
 
 #define CREATE_CHAR(TYPE,HAPCHAR,DEFVAL,MINVAL,MAXVAL,...) \
-  struct HAPCHAR : SpanCharacteristic { __VA_OPT__(enum{) __VA_ARGS__ __VA_OPT__(};) HAPCHAR(TYPE val=DEFVAL, boolean nvsStore=false) : SpanCharacteristic {&hapChars.HAPCHAR} { init<TYPE>(val,nvsStore,MINVAL,MAXVAL); } };
+  struct HAPCHAR : SpanCharacteristic { __VA_OPT__(enum Value_t {) __VA_ARGS__ __VA_OPT__(};) HAPCHAR(TYPE val=DEFVAL, boolean nvsStore=false) : SpanCharacteristic {&hapChars.HAPCHAR} { init<TYPE>(val,nvsStore,MINVAL,MAXVAL); } };
 
 namespace Characteristic {
   


### PR DESCRIPTION
This allows using enums as return values, such as this:
```
  Characteristic::SecuritySystemCurrentState::SecuritySystemCurrentStateEnum_t getState() {
    return partitionCurrentState->getVal<Characteristic::SecuritySystemCurrentState::SecuritySystemCurrentStateEnum_t>();
  }
```
Else we have to rely on returning the integer value, losing the portability of using constant names.