### PR TITLE
Add useEthernet

### DIFF
--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -101,7 +101,7 @@ void Span::init(){
   
   networkEventQueue=xQueueCreate(10,sizeof(arduino_event_id_t));    // queue to transmit network events
   Network.onEvent([](arduino_event_id_t event){xQueueSend(homeSpan.networkEventQueue, &event, (TickType_t) 0);});
-  Network.onEvent([](arduino_event_id_t event){homeSpan.ethernetEnabled=true;},arduino_event_id_t::ARDUINO_EVENT_ETH_START);   
+  Network.onEvent([](arduino_event_id_t event){homeSpan.useEthernet();},arduino_event_id_t::ARDUINO_EVENT_ETH_START);   
 }
 
 ///////////////////////////////

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -377,7 +377,7 @@ class Span{
   public:
 
   Span();         // constructor
-
+  void useEthernet() {ethernetEnabled=true;}               // use Ethernet instead of WiFi
   void begin(Category catID=DEFAULT_CATEGORY,
              const char *displayName=DEFAULT_DISPLAY_NAME,
              const char *hostNameBase=DEFAULT_HOST_NAME,


### PR DESCRIPTION
In my app does the autodection of ethernet now work.
The reason is, I have to start the network to get the KNX configuration. Depending on that, I have to create HomeSpan or not. But for this reason, Ethernet is already started and the event for starting is already sent, and HomeSpan does not get the start event.