### PR TITLE
Check new partition magic cookie only when OTA is for new partition.

### DIFF
--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -2736,7 +2736,7 @@ void SpanOTA::progress(uint32_t progress, uint32_t total){
     LOG0("%d%%..",percent);
   }
 
-  if(safeLoad && progress==total){
+  if(safeLoad && progress==total && ArduinoOTA.getCommand() == U_FLASH){
     SpanPartition newSpanPartition;   
     esp_partition_read(esp_ota_get_next_update_partition(NULL), sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t) + sizeof(esp_app_desc_t), &newSpanPartition, sizeof(newSpanPartition));
     LOG0("Checking for HomeSpan Magic Cookie: %s..",newSpanPartition.magicCookie);


### PR DESCRIPTION
To address issue #1023, when uploading SPIFF while 2nd OTA partition is empty.