### PR TITLE
Simplify Connection Logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.associations": {
+    "stdexcept": "cpp",
+    "string": "cpp"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "files.associations": {
-    "stdexcept": "cpp",
-    "string": "cpp"
-  }
-}

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1125,7 +1125,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>Compile Time:</td><td>" << homeSpan.compileTime << "</td></tr>\n";
 
   if(!homeSpan.ethernetEnabled){
-    hapOut << "<tr><td>WiFi Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n";
+    hapOut << "<tr><td>WiFi Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>WiFi Signal:</td><td>" << (int)WiFi.RSSI() << " dBm</td></tr>\n";
     if(homeSpan.bssidNames.count(WiFi.BSSIDstr().c_str()))
       hapOut << "<tr><td>BSSID:</td><td>" << WiFi.BSSIDstr().c_str() << " \"" << homeSpan.bssidNames[WiFi.BSSIDstr().c_str()].c_str() << "\"" << "</td></tr>\n";
@@ -1134,7 +1134,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>WiFi Local IP:</td><td>" << WiFi.localIP().toString().c_str() << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Gateway:</td><td>" << WiFi.gatewayIP().toString().c_str() << "</td></tr>\n";
   } else {
-    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n";
+    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>Ethernet Local IP:</td><td>" << ETH.localIP().toString().c_str() << "</td></tr>\n";    
     hapOut << "<tr><td>Ethernet Gateway:</td><td>" << ETH.gatewayIP().toString().c_str() << "</td></tr>\n";    
   }

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1125,7 +1125,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>Compile Time:</td><td>" << homeSpan.compileTime << "</td></tr>\n";
 
   if(!homeSpan.ethernetEnabled){
-    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Signal:</td><td>" << (int)WiFi.RSSI() << " dBm</td></tr>\n";
     if(homeSpan.bssidNames.count(WiFi.BSSIDstr().c_str()))
       hapOut << "<tr><td>BSSID:</td><td>" << WiFi.BSSIDstr().c_str() << " \"" << homeSpan.bssidNames[WiFi.BSSIDstr().c_str()].c_str() << "\"" << "</td></tr>\n";
@@ -1134,7 +1134,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>WiFi Local IP:</td><td>" << WiFi.localIP().toString().c_str() << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Gateway:</td><td>" << WiFi.gatewayIP().toString().c_str() << "</td></tr>\n";
   } else {
-    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n";
     hapOut << "<tr><td>Ethernet Local IP:</td><td>" << ETH.localIP().toString().c_str() << "</td></tr>\n";    
     hapOut << "<tr><td>Ethernet Gateway:</td><td>" << ETH.gatewayIP().toString().c_str() << "</td></tr>\n";    
   }

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1125,7 +1125,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>Compile Time:</td><td>" << homeSpan.compileTime << "</td></tr>\n";
 
   if(!homeSpan.ethernetEnabled){
-    hapOut << "<tr><td>WiFi Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0); << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>WiFi Signal:</td><td>" << (int)WiFi.RSSI() << " dBm</td></tr>\n";
     if(homeSpan.bssidNames.count(WiFi.BSSIDstr().c_str()))
       hapOut << "<tr><td>BSSID:</td><td>" << WiFi.BSSIDstr().c_str() << " \"" << homeSpan.bssidNames[WiFi.BSSIDstr().c_str()].c_str() << "\"" << "</td></tr>\n";
@@ -1134,7 +1134,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>WiFi Local IP:</td><td>" << WiFi.localIP().toString().c_str() << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Gateway:</td><td>" << WiFi.gatewayIP().toString().c_str() << "</td></tr>\n";
   } else {
-    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connected/2 << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0); << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>Ethernet Local IP:</td><td>" << ETH.localIP().toString().c_str() << "</td></tr>\n";    
     hapOut << "<tr><td>Ethernet Gateway:</td><td>" << ETH.gatewayIP().toString().c_str() << "</td></tr>\n";    
   }

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1125,7 +1125,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>Compile Time:</td><td>" << homeSpan.compileTime << "</td></tr>\n";
 
   if(!homeSpan.ethernetEnabled){
-    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>WiFi Signal:</td><td>" << (int)WiFi.RSSI() << " dBm</td></tr>\n";
     if(homeSpan.bssidNames.count(WiFi.BSSIDstr().c_str()))
       hapOut << "<tr><td>BSSID:</td><td>" << WiFi.BSSIDstr().c_str() << " \"" << homeSpan.bssidNames[WiFi.BSSIDstr().c_str()].c_str() << "\"" << "</td></tr>\n";
@@ -1134,7 +1134,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>WiFi Local IP:</td><td>" << WiFi.localIP().toString().c_str() << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Gateway:</td><td>" << WiFi.gatewayIP().toString().c_str() << "</td></tr>\n";
   } else {
-    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.connected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>Ethernet Local IP:</td><td>" << ETH.localIP().toString().c_str() << "</td></tr>\n";    
     hapOut << "<tr><td>Ethernet Gateway:</td><td>" << ETH.gatewayIP().toString().c_str() << "</td></tr>\n";    
   }

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1125,7 +1125,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>Compile Time:</td><td>" << homeSpan.compileTime << "</td></tr>\n";
 
   if(!homeSpan.ethernetEnabled){
-    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0); << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>WiFi Disconnects:</td><td>" <<  homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>WiFi Signal:</td><td>" << (int)WiFi.RSSI() << " dBm</td></tr>\n";
     if(homeSpan.bssidNames.count(WiFi.BSSIDstr().c_str()))
       hapOut << "<tr><td>BSSID:</td><td>" << WiFi.BSSIDstr().c_str() << " \"" << homeSpan.bssidNames[WiFi.BSSIDstr().c_str()].c_str() << "\"" << "</td></tr>\n";
@@ -1134,7 +1134,7 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
     hapOut << "<tr><td>WiFi Local IP:</td><td>" << WiFi.localIP().toString().c_str() << "</td></tr>\n";
     hapOut << "<tr><td>WiFi Gateway:</td><td>" << WiFi.gatewayIP().toString().c_str() << "</td></tr>\n";
   } else {
-    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0); << "</td></tr>\n"; // TODO: change this
+    hapOut << "<tr><td>Ethernet Disconnects:</td><td>" << homeSpan.connectionCount - (homeSpan.wifiConnected ? 1 : 0) << "</td></tr>\n"; // TODO: change this
     hapOut << "<tr><td>Ethernet Local IP:</td><td>" << ETH.localIP().toString().c_str() << "</td></tr>\n";    
     hapOut << "<tr><td>Ethernet Gateway:</td><td>" << ETH.gatewayIP().toString().c_str() << "</td></tr>\n";    
   }

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -513,7 +513,7 @@ void Span::networkCallback(arduino_event_id_t event){
 
     case ARDUINO_EVENT_ETH_DISCONNECTED:
       if(wifiConnected){   // NOTE: if connected                       // we are in a connected state
-        wifiConnected=false   // NOTE: set unconnected                        // move to unconnected state
+        wifiConnected=false;   // NOTE: set unconnected                        // move to unconnected state
         addWebLog(true,"*** Ethernet Connection Lost!");
       }
       resetStatus();     

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -454,6 +454,12 @@ void Span::networkCallback(arduino_event_id_t event){
   
   switch (event) {
       
+    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
+      connected=true;
+      connectionCount++;
+      addWebLog(true,"WiFi Connected! (RSI=%d  BSSID=%s)",WiFi.RSSI(),WiFi.BSSIDstr().c_str());
+    break;
+    
     case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
       if(connected){ // we are in a connected state
         connected=false; // move to unconnected state
@@ -464,18 +470,12 @@ void Span::networkCallback(arduino_event_id_t event){
       resetStatus();     
     break;
       
-    case ARDUINO_EVENT_WIFI_STA_CONNECTED:
-      connected=true;
-      connectionCount++;
-      addWebLog(true,"WiFi Connected! (RSI=%d  BSSID=%s)",WiFi.RSSI(),WiFi.BSSIDstr().c_str());
-      break;
-      
     case ARDUINO_EVENT_WIFI_STA_GOT_IP:
     case ARDUINO_EVENT_WIFI_STA_GOT_IP6:
       if(bssidNames.count(WiFi.BSSIDstr().c_str()))
-        addWebLog(true,"WiFi Connected!  IP Address = %s   (RSI=%d  BSSID=%s  \"%s\")",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str(),bssidNames[WiFi.BSSIDstr().c_str()].c_str());
+        addWebLog(true,"WiFi got an IP!  IP Address = %s   (RSI=%d  BSSID=%s  \"%s\")",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str(),bssidNames[WiFi.BSSIDstr().c_str()].c_str());
       else
-        addWebLog(true,"WiFi Connected!  IP Address = %s   (RSI=%d  BSSID=%s)",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str());      
+        addWebLog(true,"WiFi got an IP!  IP Address = %s   (RSI=%d  BSSID=%s)",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str());      
       if(connected)
         configureNetwork();
       if(connectionCallback)
@@ -507,13 +507,19 @@ void Span::networkCallback(arduino_event_id_t event){
 
     case ARDUINO_EVENT_ETH_GOT_IP:
     case ARDUINO_EVENT_ETH_GOT_IP6:
-      addWebLog(true,"Ethernet Connected!  IP Address = %s",ETH.localIP().toString().c_str());      
+      addWebLog(true,"Ethernet got an IP!  IP Address = %s",ETH.localIP().toString().c_str());      
       if(connected)
         configureNetwork();
       if(connectionCallback)
         connectionCallback(connectionCount);
       resetStatus();     
     break;
+    
+    case ARDUINO_EVENT_ETH_CONNECTED:
+      connected=true;
+      connectionCount++;
+      addWebLog(true,"Ethernet Connected!");
+      break;
 
     case ARDUINO_EVENT_ETH_DISCONNECTED:
       if(connected){ // we are in a connected state

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -269,7 +269,7 @@ void Span::pollTask() {
     
   } // isInitialized
 
-  if(!ethernetEnabled && strlen(network.wifiData.ssid) && !(connected%2) && millis()>alarmConnect){
+  if(!ethernetEnabled && strlen(network.wifiData.ssid) && !(connected%2) && millis()>alarmConnect){ // Note: if disconnected
     if(verboseWifiReconnect)
       addWebLog(true,"Trying to connect to %s.  Waiting %ld sec...",network.wifiData.ssid,wifiTimeCounter/1000);
     
@@ -455,8 +455,8 @@ void Span::networkCallback(arduino_event_id_t event){
   switch (event) {
       
     case ARDUINO_EVENT_WIFI_STA_DISCONNECTED:
-      if(connected%2){                        // we are in a connected state
-        connected++;                          // move to unconnected state
+      if(connected%2){ // NOTE: if connected                       // we are in a connected state
+        connected++;   // NOTE: move to unconnected                        // move to unconnected state
         addWebLog(true,"*** WiFi Connection Lost!");
         wifiTimeCounter.reset();
         alarmConnect=millis();
@@ -470,11 +470,11 @@ void Span::networkCallback(arduino_event_id_t event){
         addWebLog(true,"WiFi Connected!  IP Address = %s   (RSI=%d  BSSID=%s  \"%s\")",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str(),bssidNames[WiFi.BSSIDstr().c_str()].c_str());
       else
         addWebLog(true,"WiFi Connected!  IP Address = %s   (RSI=%d  BSSID=%s)",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str());      
-      connected++;
-      if(connected==1)
+      connected++;  // NOTE: set to connected
+      if(connected==1) // NOTE: if connected
         configureNetwork();
       if(connectionCallback)
-        connectionCallback((connected+1)/2);
+        connectionCallback((connected+1)/2); // NOTE: send number of connection events
       if(rescanInitialTime>0){
         rescanAlarm=millis()+rescanInitialTime;
         rescanStatus=RESCAN_PENDING;
@@ -503,17 +503,17 @@ void Span::networkCallback(arduino_event_id_t event){
     case ARDUINO_EVENT_ETH_GOT_IP:
     case ARDUINO_EVENT_ETH_GOT_IP6:
       addWebLog(true,"Ethernet Connected!  IP Address = %s",ETH.localIP().toString().c_str());      
-      connected++;
-      if(connected==1)
+      connected++; // NOTE: set to connected
+      if(connected==1) // NOTE: set to connected
         configureNetwork();
       if(connectionCallback)
-        connectionCallback((connected+1)/2);
+        connectionCallback((connected+1)/2); // NOTE: send number of connection events
       resetStatus();     
     break;
 
     case ARDUINO_EVENT_ETH_DISCONNECTED:
-      if(connected%2){                        // we are in a connected state
-        connected++;                          // move to unconnected state
+      if(connected%2){   // NOTE: if connected                       // we are in a connected state
+        connected++;   // NOTE: set unconnected                        // move to unconnected state
         addWebLog(true,"*** Ethernet Connection Lost!");
       }
       resetStatus();     
@@ -1342,7 +1342,7 @@ void Span::getWebLog(void (*f)(const char *, void *), void *user_data){
 void Span::resetStatus(){
   if(!ethernetEnabled && strlen(network.wifiData.ssid)==0)
     STATUS_UPDATE(start(LED_WIFI_NEEDED),HS_WIFI_NEEDED)
-  else if(!(connected%2))
+  else if(!(connected%2)) // NOTE: if Connected
     STATUS_UPDATE(start(LED_WIFI_CONNECTING),ethernetEnabled?HS_ETH_CONNECTING:HS_WIFI_CONNECTING)
   else if(!HAPClient::nAdminControllers())
     STATUS_UPDATE(start(LED_PAIRING_NEEDED),HS_PAIRING_NEEDED)

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -471,6 +471,7 @@ void Span::networkCallback(arduino_event_id_t event){
       else
         addWebLog(true,"WiFi Connected!  IP Address = %s   (RSI=%d  BSSID=%s)",WiFi.localIP().toString().c_str(),WiFi.RSSI(),WiFi.BSSIDstr().c_str());      
       wifiConnected=true;  // NOTE: set to connected
+      connectionCount++; // NOTE: increment connection count
       if(wifiConnected) // NOTE: if connected
         configureNetwork();
       if(connectionCallback)
@@ -504,6 +505,7 @@ void Span::networkCallback(arduino_event_id_t event){
     case ARDUINO_EVENT_ETH_GOT_IP6:
       addWebLog(true,"Ethernet Connected!  IP Address = %s",ETH.localIP().toString().c_str());      
       wifiConnected=true; // NOTE: set to connected
+      connectionCount++; // NOTE: increment connection count
       if(wifiConnected) // NOTE: set to connected
         configureNetwork();
       if(connectionCallback)

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -295,7 +295,7 @@ class Span{
   nvs_handle hapNVS;                            // handle for non-volatile-storage of HAP data
 
   // odd = not connected, even = connected
-  int connected=0;                              // WiFi connection status (increments upon each connect and disconnect)
+  // int connected=0;                              // WiFi connection status (increments upon each connect and disconnect)
   int connectionCount=0;                        // number of times WiFi has been connected (increments upon each connect)
   boolean wifiConnected=false;                  // flag indicating whether WiFi is connected
   HS_ExpCounter wifiTimeCounter;                // exponentially-increasing wait time counter between WiFi connection attempts

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -294,7 +294,10 @@ class Span{
   nvs_handle srpNVS;                            // handle for non-volatile storage of SRP data
   nvs_handle hapNVS;                            // handle for non-volatile-storage of HAP data
 
+  // odd = not connected, even = connected
   int connected=0;                              // WiFi connection status (increments upon each connect and disconnect)
+  int connectionCount=0;                        // number of times WiFi has been connected (increments upon each connect)
+  boolean wifiConnected=false;                  // flag indicating whether WiFi is connected
   HS_ExpCounter wifiTimeCounter;                // exponentially-increasing wait time counter between WiFi connection attempts
   unsigned long alarmConnect=0;                 // time after which WiFi connection attempt should be tried again
 

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -294,10 +294,8 @@ class Span{
   nvs_handle srpNVS;                            // handle for non-volatile storage of SRP data
   nvs_handle hapNVS;                            // handle for non-volatile-storage of HAP data
 
-  // odd = not connected, even = connected
-  // int connected=0;                              // WiFi connection status (increments upon each connect and disconnect)
   int connectionCount=0;                        // number of times WiFi has been connected (increments upon each connect)
-  boolean wifiConnected=false;                  // flag indicating whether WiFi is connected
+  boolean connected=false;                  // flag indicating whether WiFi is connected
   HS_ExpCounter wifiTimeCounter;                // exponentially-increasing wait time counter between WiFi connection attempts
   unsigned long alarmConnect=0;                 // time after which WiFi connection attempt should be tried again
 


### PR DESCRIPTION
Simplifying the connection logic from even and odd to just true and false with a connection counter. 

This should solve #1081 and allow HomeSpan to receive any number of IPv6 addresses without assuming the connection dropped. 

## Changes
- Switched from connected(int) to connected(bool)
- Created new connectionCount
- Using `ARDUINO_EVENT_WIFI_STA_CONNECTED` and `ARDUINO_EVENT_ETH_CONNECTED`  to detect when we connect 
- Updated HAP.cpp with new logic 

## Testing
I've imported and built a version of [homekit-ratgdo32](https://github.com/ratgdo/homekit-ratgdo32) with this branch and it looks like the disconnections have gone away. 

<img width="402" alt="Screenshot 2025-06-16 at 10 20 07 PM" src="https://github.com/user-attachments/assets/b903db12-8db1-4998-9bf2-515c0b47c9ba" />
