### PR TITLE
HTML compliance fix. Make sure html meta tag is in head tag.

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -241,8 +241,8 @@ void Network_HS::apConfigure(){
 void Network_HS::processRequest(char *body, char *formData){
   
   String responseHead="HTTP/1.1 200 OK\r\nContent-type: text/html\r\n";
-  
-  String responseBody="<html><meta charset=\"utf-8\"><head><style>"
+  String metaTags = "<meta charset=\"utf-8\">";
+  String responseBody="<html><head>__META__<style>"
                         "p{font-size:300%; margin:1em}"
                         "label{font-size:300%; margin:1em}"
                         "input{font-size:250%; margin:1em}"
@@ -281,8 +281,8 @@ void Network_HS::processRequest(char *body, char *formData){
       apStatus=1;
       
     } else {
-    responseBody+="<meta http-equiv = \"refresh\" content = \"4; url = /wifi-status\" />"
-                  "<p><b>Disallowed Setup Code - too simple!</b></p><p>Returning to configuration page...</p>";      
+      metaTags+="<meta http-equiv=\"refresh\" content=\"4;url=/wifi-status\" />";
+      responseBody+="<p><b>Disallowed Setup Code - too simple!</b></p><p>Returning to configuration page...</p>";      
     }
     
   } else
@@ -352,8 +352,10 @@ void Network_HS::processRequest(char *body, char *formData){
                   
   }
 
-  responseHead+="\r\n";               // add blank line between reponse header and body
-  responseBody+="</body></html>";     // close out body and html tags
+  responseBody+="</body></html>\r\n\r\n";     // close out body and html tags
+  responseBody.replace("__META__", metaTags); // insert meta tag in <head>
+  responseHead+="Content-Length: " + String(responseBody.length()) + "\r\n";
+  responseHead+="\r\n";                       // add blank line between reponse header and body
 
   LOG2("\n>>>>>>>>>> ");
   LOG2(client.remoteIP());


### PR DESCRIPTION
While looking at initial access point connection issues I noticed the HTML `meta` tags were not in `head`. This PR improves html compliance.