### PR TITLE
Improve Content-Length parsing & error handling, Reimplement Nonce::inc() for security

### DIFF
--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -171,7 +171,7 @@ void HAPClient::processRequest(){
   int cLen=0;                         // length of optional HTTP Content
 
   if((p=strstr(body,"Content-Length: "))){       // Content-Length is specified
-    if(sscanf(p+16, "%d", &cLen) != 1 || cLen < 0 || cLen > MAX_HTTP){       // Parsing succeeded, specified Content-Length is within limits
+    if(sscanf(p+16, "%d", &cLen) != 1 || cLen < 0 || cLen > MAX_HTTP){       // Verify parsing succeeded and specified Content-Length is within limits
       badRequestError();
       LOG0("\n*** ERROR: Invalid Content-Length\n\n");
       return;

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -104,6 +104,8 @@ void Span::init(){
 
   log_i("Initializing Span");
 
+  WiFi.mode(WIFI_STA);                                    // enable WiFi radio - required for random number generator entropy seeding
+ 
   WiFi.setAutoReconnect(false);                           // allow HomeSpan to handle disconnect/reconnect logic
   WiFi.persistent(false);                                 // do not permanently store WiFi configuration data
   WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);              // scan ALL channels - do NOT stop at first SSID match, else you could connect to weaker BSSID

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -80,7 +80,12 @@ void Network_HS::serialConfigure(){
     LOG0("\n>>> WiFi SSID: ");
     readSerial(wifiData.ssid,MAX_SSID);
     if(atoi(wifiData.ssid)>0 && atoi(wifiData.ssid)<=numSSID){
-      strcpy(wifiData.ssid,ssidList[atoi(wifiData.ssid)-1]);
+      char *selectedSSID=ssidList[atoi(wifiData.ssid)-1];
+      if(strlen(selectedSSID)>MAX_SSID){
+        LOG0("\n*** ERROR: Invalid SSID length.  Please select a different network.\n");
+        wifiData.ssid[0]='\0';
+      }
+      else strcpy(wifiData.ssid,selectedSSID);
     }
     LOG0("%s\n",wifiData.ssid);
   }


### PR DESCRIPTION
HAP.cpp:
1. Rewrite Nonce::inc() to use all bytes (4-11) to prevent nonce reuse
2. Improved Content-Length validation and error handling
3. Fix potential buffer overflow when testing decrypted content length

Network.cpp:
1. During serial Wi-Fi configuration, verify broadcasted SSID string length to guard against overflow and prompt user to select a different SSID if necessary

HomeSpan.cpp:
1. Even if ETH interface is initialized, we need access to an entropy source, so we set Wi-Fi station mode during HomeSpan initialization.