### PR TITLE
Add optional additional Pair-Setup window

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -243,6 +243,15 @@ The following **optional** `homeSpan` methods enable additional features and pro
   * note this method differs from `setPairCallback()`, which is only called if the device's pairing status changes, such as when the first controller is added during initial pairing, or the last controller is removed when unpairing
   * the function *func* must be of type *void* and have no arguments
   * see the `controllerListBegin()` and `controllerListEnd()` methods for details on how to read the pairing data for each paired controller (*only needed to support certain advanced use cases*)
+
+* `Span& setAdditionalPairing(boolean enabled=true)`
+  * allows a device that is already paired with at least one controller to accept another HomeKit Pair-Setup request, so a sketch can temporarily open a pairing window for additional controllers
+  * when enabled, HomeSpan advertises the accessory as pairable in its HAP MDNS Status Flag even if one or more admin controllers are already paired
+  * when disabled, HomeSpan returns to its default behavior and rejects Pair-Setup requests once at least one admin controller is paired
+  * sketches should only enable this while the user has explicitly requested pairing, for example after a physical button press or through a trusted local maintenance interface, and should disable it again after a short pairing window
+
+* `boolean getAdditionalPairing()`
+  * returns true if additional Pair-Setup is currently enabled, else false
  
 * `std::pair< HS_STATUS, uint32_t > getStatus()`
   * returns a std::pair containing:

--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -333,7 +333,7 @@ int HAPClient::postPairSetupURL(uint8_t *content, size_t len){
 
   int tlvState=itState->getVal();
 
-  if(nAdminControllers()){                                  // error: Device already paired (i.e. there is at least one admin Controller). We should not be receiving any requests for Pair-Setup!
+  if(nAdminControllers() && !homeSpan.getAdditionalPairing()){ // error: Device already paired and additional Pair-Setup is not enabled
     LOG0("\n*** ERROR: Device already paired!\n\n");
     responseTLV.add(kTLVType_State,tlvState+1);             // set response STATE to requested state+1 (which should match the state that was expected by the controller)
     responseTLV.add(kTLVType_Error,tagError_Unavailable);   // set Error=Unavailable
@@ -539,7 +539,7 @@ int HAPClient::postPairSetupURL(uint8_t *content, size_t len){
       delete srp;                                           // delete SRP - no longer needed once pairing is completed
       srp=NULL;                                             // reset to NULL
 
-      mdns_service_txt_item_set("_hap","_tcp","sf","0");    // broadcast new status
+      homeSpan.updatePairingStatusFlag();                   // broadcast new status
       
       LOG1("\n*** ACCESSORY PAIRED! ***\n");
 
@@ -1431,7 +1431,7 @@ void HAPClient::removeController(uint8_t *id){
     
     tearDown(NULL);                                              // teardown all remaining connections
     controllerList.clear();                                      // remove all remaining Controllers
-    mdns_service_txt_item_set("_hap","_tcp","sf","1");           // set Status Flag = 1 (Table 6-8)
+    homeSpan.updatePairingStatusFlag();                          // update Status Flag (Table 6-8)
     homeSpan.resetStatus();                                      // reset hsStatus and StatusLED
     if(homeSpan.pairCallback)                                    // if set, invoke user-defined Pairing Callback to indicate device has been un-paired
       homeSpan.pairCallback(false);    

--- a/src/HomeSpan.cpp
+++ b/src/HomeSpan.cpp
@@ -565,6 +565,7 @@ void Span::configureNetwork(){
   MDNS.begin(hostName);                         // set server host name (.local implied)
   MDNS.setInstanceName(displayName);            // set server display name
   MDNS.addService("_hap","_tcp",tcpPortNum);    // advertise HAP service on specified port
+  hapServiceMDNSStarted=true;
 
   // add MDNS (Bonjour) TXT records for configurable as well as fixed values (HAP Table 6-7)
 
@@ -580,10 +581,7 @@ void Span::configureNetwork(){
   mdns_service_txt_item_set("_hap","_tcp","pv","1.1");           // HAP version - MUST be set to "1.1" (HAP Section 6.6.3)
   mdns_service_txt_item_set("_hap","_tcp","s#","1");             // HAP current state - MUST be set to "1"
 
-  if(!HAPClient::nAdminControllers())                            // Accessory is not yet paired
-    mdns_service_txt_item_set("_hap","_tcp","sf","1");           // set Status Flag = 1 (Table 6-8)
-  else
-    mdns_service_txt_item_set("_hap","_tcp","sf","0");           // set Status Flag = 0
+  updatePairingStatusFlag();                                     // set Status Flag (Table 6-8)
 
   mdns_service_txt_item_set("_hap","_tcp","hspn",HOMESPAN_VERSION);             // HomeSpan Version Number (info only - NOT used by HAP)
   mdns_service_txt_item_set("_hap","_tcp","ard-esp32",ARDUINO_ESP_VERSION);     // Arduino-ESP32 Version Number (info only - NOT used by HAP)
@@ -642,6 +640,25 @@ void Span::configureNetwork(){
     wifiCallback();
   
 } // initWiFi
+
+///////////////////////////////
+
+void Span::updatePairingStatusFlag(){
+
+  if(!hapServiceMDNSStarted)
+    return;
+
+  mdns_service_txt_item_set("_hap","_tcp","sf",(!HAPClient::nAdminControllers() || additionalPairingEnabled) ? "1" : "0");
+}
+
+///////////////////////////////
+
+Span& Span::setAdditionalPairing(boolean enabled){
+
+  additionalPairingEnabled=enabled;
+  updatePairingStatusFlag();
+  return(*this);
+}
 
 ///////////////////////////////
 
@@ -910,7 +927,7 @@ void Span::processSerialCommand(const char *c){
       HAPClient::tearDown(NULL);                                                // tear down all verified connections
             
       LOG0("\nDEVICE NOT YET PAIRED -- PLEASE PAIR WITH HOMEKIT APP\n\n");
-      mdns_service_txt_item_set("_hap","_tcp","sf","1");                        // set Status Flag = 1 (Table 6-8)
+      updatePairingStatusFlag();                                                // update Status Flag (Table 6-8)
 
       if(homeSpan.pairCallback)
         homeSpan.pairCallback(false);

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -295,6 +295,8 @@ class Span{
   boolean ethernetEnabled=false;                // flag to indicate whether Ethernet is being used instead of WiFi
   boolean initialPollingCompleted=false;        // flag to indicate whether polling task has initially completed
   boolean forceConfigIncrement=false;           // flag to indicate whether configuration number (MDNS C# value) should be incremented even if database config has not changed
+  boolean additionalPairingEnabled=false;       // flag to allow Pair-Setup for additional Controllers after initial pairing
+  boolean hapServiceMDNSStarted=false;          // flag indicating whether the HAP MDNS service has been started
   char *compileTime=NULL;                       // optional compile time string --- can be set with call to setCompileTime()
   HS_STATUS hsStatus=HS_INITIAL_SETUP;          // current HomeSpan status
   uint32_t hsStatusTime;                        // timestamp (in seconds) of latest recent HomeSpan status update
@@ -369,6 +371,7 @@ class Span{
 
   void pollTask();                                                       // poll HAP Clients and process any new HAP requests
   void configureNetwork();                                               // configure Network services (MDNS, WebLog,  OTA, etc.) and start HAP Server
+  void updatePairingStatusFlag();                                        // update MDNS Status Flag according to current pairing state
   void commandMode();                                                    // allows user to control and reset HomeSpan settings with the control button
   void setStatus(HS_STATUS hst);                                         // sets hsStatus to hst, updates statusLED, and calls statusCallback
   void resetStatus();                                                    // resets hsStatus, updates statusLED, and calls statusCallback
@@ -467,6 +470,8 @@ class Span{
   void deleteStoredValues(){processSerialCommand("V");}                                  // deletes stored Characteristic values from NVS
   Span& resetIID(uint32_t newIID);                                                       // resets the IID count for the current Accessory to start at newIID
   Span& setControllerCallback(void (*f)()){controllerCallback=f;return(*this);}          // sets an optional user-defined function to call whenever a Controller is added/removed
+  Span& setAdditionalPairing(boolean enabled=true);                                      // enables/disables additional Pair-Setup after initial pairing
+  boolean getAdditionalPairing(){return(additionalPairingEnabled);}                       // returns true if additional Pair-Setup is enabled
   Span& setWifiBegin(void (*f)(const char *, const char *)){wifiBegin=f;return(*this);}  // sets an optional user-defined function to over-ride WiFi.begin() with additional logic
   Span& setPollingCallback(void (*f)()){pollingCallback=f;return(*this);}                // sets an optional user-defined function to call upon INITIAL completion of the polling task (only called once)
   Span& useEthernet(){ethernetEnabled=true;return(*this);}                               // force use of Ethernet instead of WiFi, even if ETH not called or Ethernet card not detected


### PR DESCRIPTION
## Summary
- Add `homeSpan.setAdditionalPairing()` / `getAdditionalPairing()` so sketches can temporarily allow Pair-Setup after the first admin controller is already paired.
- Keep the existing default behavior unchanged: already-paired accessories reject Pair-Setup unless a sketch explicitly enables additional pairing.
- Update the HAP mDNS `sf` status flag through a shared helper so controllers can discover the temporary pairing window.

## Motivation
Some deployments need to add the same accessory to more than one native HomeKit controller/admin. A practical example is commissioning the accessory first in Apple Home and later commissioning it natively in Home Assistant using its HomeKit Controller integration, without using a bridge or proxy layer.

This lets sketches implement their own policy for opening that additional pairing window, such as a physical button, trusted local admin endpoint, or short timeout, without changing HomeSpan defaults.

## Validation
- `git diff --check`
- PlatformIO compile test against a minimal ESP32 sketch using `homeSpan.setAdditionalPairing(true);`

## Security note
This does not automatically reopen pairing. Sketches must opt in and should only enable it in response to an explicit trusted action, then disable it again after a short window.