### PR TITLE
Add ability to use a CSS file for the web log instead of inline CSS.

### DIFF
--- a/src/HAP.cpp
+++ b/src/HAP.cpp
@@ -1106,8 +1106,12 @@ void HAPClient::getStatusURL(HAPClient *hapClient, void (*callBack)(const char *
 
   if(homeSpan.webLog.faviconURL)
     hapOut << "<link rel=\"icon\" href=\"" << homeSpan.webLog.faviconURL << "\" type=\"image/png\" />\n";
-    
-  hapOut << "<style>body {background-color:lightblue;} th, td {padding-right: 10px; padding-left: 10px; border:1px solid black;}" << homeSpan.webLog.css.c_str() << "</style></head>\n";
+  
+  if (homeSpan.webLog.cssURI)
+    hapOut << "<link rel=\"stylesheet\" href=\"" << homeSpan.webLog.css.c_str() << "\" type=\"text/css\" />\n";
+  else
+    hapOut << "<style>body {background-color:lightblue;} th, td {padding-right: 10px; padding-left: 10px; border:1px solid black;}" << homeSpan.webLog.css.c_str() << "</style></head>\n";
+  
   hapOut << "<body class=\"body bod1\"><h2>" << homeSpan.displayName << "</h2>\n";
   
   hapOut << "<table class=\"infoTable tab1\">\n";

--- a/src/HomeSpan.h
+++ b/src/HomeSpan.h
@@ -224,6 +224,7 @@ struct SpanWebLog{                            // optional web status/log data
   char *faviconURL=NULL;                      // optional URL for favicon PNG image
   uint32_t waitTime=120000;                   // number of milliseconds to wait for initial connection to time server
   String css="";                              // optional user-defined style sheet for web log
+  boolean cssURI=false;                      // flag to indicate whether user-defined style sheet is a URI or inline CSS
   std::shared_mutex mux;                      // shared read/write lock
     
   struct log_t {                              // log entry type
@@ -494,7 +495,7 @@ class Span{
     va_end(ap);    
   }
 
-  Span& setWebLogCSS(const char *css){webLog.css="\n" + String(css) + "\n";return(*this);}
+  Span& setWebLogCSS(const char *css, boolean isURI=false){if (isURI) webLog.css=css; else webLog.css="\n" + String(css) + "\n"; webLog.cssURI=isURI; return(*this);}
   Span& setWebLogCallback(void (*f)(String &)){weblogCallback=f;return(*this);}
   Span& setWebLogFavicon(const char *favicon=DEFAULT_FAVICON){asprintf(&webLog.faviconURL,"%s",favicon);return(*this);}
   void getWebLog(void (*f)(const char *, void *), void *);


### PR DESCRIPTION
**Some context**

Using `homeSpan.getWebLog()` to get weblogs from a different URI, configured with a separate webserver listening on a different port, HomeSpan will generate the full HTML page. No issues here.

I now need to send the following HTTP header to protect against XSS:
```c
  httpd_resp_set_hdr(req,
    "Content-Security-Policy",
    "default-src 'self'; "
    "script-src 'self'; "
    "object-src 'none'; "
    "base-uri 'none'; "
    "frame-ancestors 'none'");
```

This now causes Chrome to abort the connection with this error:
```
Applying inline style violates the following Content Security Policy directive 'default-src 'self''. 
Either the 'unsafe-inline' keyword, a hash ('sha256-9uMUYPNHTeOWAevYKamF1ilLlQzsK3ALyCpUeBf/i5c='), 
or a nonce ('nonce-...') is required to enable inline execution. Note also that 'style-src' was not explicitly set, 
so 'default-src' is used as a fallback. The action has been blocked.
```

The error is caused by the inline `<style>...</style>` in the HTML generated by HomeSpan.

To address this issue, and make HomeSpan more secure, the `setWeblogCSS()` method has been enhanced with an optional parameter, `isURI`, defaulting to `false`. If set to `true`, the string passed to `setWeblogCSS()` is expected to be a URI, full or relative, to a .css file.

**Example:**
Prior to the change, I used this:
```c
homeSpan.setWebLogCSS("</style><link rel=\"stylesheet\" href=\"/static/style.css\"><style>");`
```
which generated this:
```html
<style>body {background-color:lightblue;} th, td {padding-right: 10px; padding-left: 10px; border:1px solid black;}
</style><link rel="stylesheet" href="/static/style.css"><style>
</style></head>
```

Now with the change, we can simply call this:
```c
homeSpan.setWebLogCSS("/static/style.css", true);
```

And HomeSpan will generate this:
```html
<link rel="stylesheet" href="/static/style.css" type="text/css" />
```

The security warning no longer appears.